### PR TITLE
chore: fix homepage url to point to correct Snyk org

### DIFF
--- a/packages/child-process/package.json
+++ b/packages/child-process/package.json
@@ -20,7 +20,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk-tech-services/python-fix"
+    "url": "https://github.com/snyk/python-fix"
   },
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "bin",
     "dist"
   ],
-  "homepage": "https://github.com/snyk-tech-services/python-fix#readme",
+  "homepage": "https://github.com/snyk/python-fix#readme",
   "dependencies": {
     "debug": "^4.1.1",
     "source-map-support": "^0.5.16",

--- a/packages/pip-requirements/package.json
+++ b/packages/pip-requirements/package.json
@@ -20,7 +20,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk-tech-services/python-fix"
+    "url": "https://github.com/snyk/python-fix"
   },
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "bin",
     "dist"
   ],
-  "homepage": "https://github.com/snyk-tech-services/python-fix#readme",
+  "homepage": "https://github.com/snyk/python-fix#readme",
   "dependencies": {
     "debug": "^4.1.1",
     "tslib": "^1.10.0"

--- a/packages/pipenv-pipfile/package.json
+++ b/packages/pipenv-pipfile/package.json
@@ -20,7 +20,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk-tech-services/python-fix"
+    "url": "https://github.com/snyk/python-fix"
   },
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "bin",
     "dist"
   ],
-  "homepage": "https://github.com/snyk-tech-services/python-fix#readme",
+  "homepage": "https://github.com/snyk/python-fix#readme",
   "dependencies": {
     "@snyk/child-process": "^0.3.1",
     "bottleneck": "2.19.5",

--- a/packages/poetry/package.json
+++ b/packages/poetry/package.json
@@ -20,7 +20,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk-tech-services/python-fix"
+    "url": "https://github.com/snyk/python-fix"
   },
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "bin",
     "dist"
   ],
-  "homepage": "https://github.com/snyk-tech-services/python-fix#readme",
+  "homepage": "https://github.com/snyk/python-fix#readme",
   "dependencies": {
     "@snyk/child-process": "^0.3.1",
     "bottleneck": "2.19.5",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Fix broken links in package.json and `npm`