### PR TITLE
fix: bypass Snyk CLI proxy [FIX-138]

### DIFF
--- a/packages/child-process/test/system/sub-process.spec.ts
+++ b/packages/child-process/test/system/sub-process.spec.ts
@@ -21,6 +21,7 @@ describe('execute', () => {
       stdout: '',
     });
   });
+
   it('returns all stderr data when command is invalid', async () => {
     const res = await execute('node', ['--python', '1.2.3'], {});
     // created while running the above command that fails
@@ -32,4 +33,39 @@ describe('execute', () => {
       stdout: '',
     });
   }, 30000);
+
+  it('restores any HTTP_PROXY related environment variables', async () => {
+    // Other Env
+    process.env.MY_ENV_VAR = 'hello world';
+
+    // Snyk CLI Settings
+    process.env.NO_PROXY = '';
+    process.env.HTTP_PROXY = 'http://snyk-proxy:8080';
+    process.env.HTTPS_PROXY = 'https://snyk-proxy:8080';
+
+    // User Defaults
+    process.env.SNYK_SYSTEM_NO_PROXY =
+      'internal.example.com,internal2.example.com';
+    process.env.SNYK_SYSTEM_HTTP_PROXY = 'http://my-org-proxy:8080';
+    process.env.SNYK_SYSTEM_HTTPS_PROXY = 'https://my-org-proxy:8080';
+
+    const res = await execute(
+      'node',
+      ['-pe', 'JSON.stringify(process.env)'],
+      {},
+    );
+    expect(res).toEqual({
+      command: expect.any(String),
+      duration: expect.any(Number),
+      exitCode: 0,
+      stderr: '',
+      stdout: expect.any(String),
+    });
+
+    const env = JSON.parse(res.stdout);
+    expect(env.NO_PROXY).toEqual('internal.example.com,internal2.example.com');
+    expect(env.HTTP_PROXY).toEqual('http://my-org-proxy:8080');
+    expect(env.HTTPS_PROXY).toEqual('https://my-org-proxy:8080');
+    expect(env.MY_ENV_VAR).toEqual('hello world');
+  });
 });

--- a/packages/child-process/test/tsconfig.json
+++ b/packages/child-process/test/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts"]
+  "include": ["../**/*.ts"]
 }


### PR DESCRIPTION
The Go wrapper in the Snyk CLI uses an internal HTTP proxy between itself and the NodeJS tool. This causes issues for external tools executed in subprocesses such as python-fix shelling out to `pipenv` or `poetry`. 

Snyk CLI caches the original values in environment variables before overriding them, e.g. `HTTP_PROXY` is stored in `SNYK_SYSTEM_HTTP_PROXY`. So we use these cached values to restore the originals and pass the `env` option to [`spawn()`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) to create the subprocess.

This change will fix issues with the `snyk fix` command failing to reach the `pypi` package repository.

Fixes FIX-138